### PR TITLE
Uncaught Error: Audio key "pong-beep" missing from cache

### DIFF
--- a/src/scenes/Preload.js
+++ b/src/scenes/Preload.js
@@ -1,34 +1,32 @@
 //import Phaser from './phaser'
+class Preload extends Phaser.Scene {
 
+    constructor() {
+        super('preload')
+    }
+    preload() {
+        this.add.text(200, 200, 'hi')
 
+        // Set the asset load path
+        this.load.setPath('public/assets/');
 
- class Preload extends Phaser.Scene 
-{
-  
-  constructor() {
-    super('preload')
-  }
-	preload()
-	{
-		this.add.text(200,200,'hi')
-		
-		    this.load.setPath('public/assets/');
+        
+        //this.load.audio('pong-beep', '../../public/assets/ping_pong_8bit_beeep.ogg')
+        // does NOT handle long paths containing ../../ so please avoid
+        
+        
+        this.load.audio('pong-beep', 'ping_pong_8bit_beeep.ogg')
+        this.load.audio('pong-plop', 'ping_pong_8bit_plop.ogg')
+    }
 
-		this.load.audio('pong-beep','ping_pong_8bit_beeep.ogg')
-		this.load.audio('pong-plop','ping_pong_8bit_plop.ogg')
-	}
+    create() {
+        console.log('preload');
+        
+        var beep = this.sound.add('pong-beep');
 
-	create()
-	{
-	  console.log('preload');
-//          this.sound.add('pong-beep');
-
-    var beep = this.sound.add('pong-beep');
-
-
-//this.sound.add('beep');
-	  
-	  console.log(this.cache.audio.getKeys());
-		this.scene.start('titlescreen');
-	}
+        console.log(this.cache.audio.getKeys());
+        
+        this.scene.start('titlescreen');
+        
+    }
 }

--- a/src/scenes/Preload.js
+++ b/src/scenes/Preload.js
@@ -1,6 +1,7 @@
 //import Phaser from './phaser'
 
 
+
  class Preload extends Phaser.Scene 
 {
   
@@ -10,13 +11,24 @@
 	preload()
 	{
 		this.add.text(200,200,'hi')
-		this.load.audio('pong-beep','../../public/assets/ping_pong_8bit_beeep.ogg')
-	this.load.audio('pong-plop','../../public/assets/ping_pong_8bit_plop.ogg')
+		
+		    this.load.setPath('public/assets/');
+
+		this.load.audio('pong-beep','ping_pong_8bit_beeep.ogg')
+		this.load.audio('pong-plop','ping_pong_8bit_plop.ogg')
 	}
 
 	create()
 	{
-	  console.log('preload')
-		this.scene.start('titlescreen')
+	  console.log('preload');
+//          this.sound.add('pong-beep');
+
+    var beep = this.sound.add('pong-beep');
+
+
+//this.sound.add('beep');
+	  
+	  console.log(this.cache.audio.getKeys());
+		this.scene.start('titlescreen');
 	}
 }


### PR DESCRIPTION
The path you used IS correct but for some reason Phaser3 does not like paths that contain "../../" so to resolve the problem I set the asset load path to:         

this.load.setPath('public/assets/');
Then loaded the audio: this.load.audio('pong-beep', 'ping_pong_8bit_beeep.ogg')

Then used a var to grab a reference to the audio asset:
var beep = this.sound.add('pong-beep');

